### PR TITLE
Add "confidence" option.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,15 +47,11 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-math3 -->
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.8.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.8.1</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>theta</artifactId>
-    <version>0.1.3</version>
+    <version>0.2.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A portable timing library</description>

--- a/src/main/scala/io/citrine/theta/Profiler.scala
+++ b/src/main/scala/io/citrine/theta/Profiler.scala
@@ -4,10 +4,11 @@ package io.citrine.theta
   * Created by maxhutch on 4/21/17.
   */
 class Profiler(name: String, benchmark: String = "Default",
-               minRun: Int = 8, maxRun: Int = 64, targetError: Double = 0.01) {
+               minRun: Int = 8, maxRun: Int = 64,
+               targetError: Double = 0.05, confidence: Double = 0.95) {
 
   def profile[R](block: Counter => R): ProfilerReport = {
-    val time = Stopwatch.wallclock({block(new Counter())}, minRun, maxRun, targetError)
+    val time = Stopwatch.wallclock({block(new Counter())}, minRun, maxRun, targetError, confidence)
     val counter = new Counter()
     block(counter)
 

--- a/src/main/scala/io/citrine/theta/Stopwatch.scala
+++ b/src/main/scala/io/citrine/theta/Stopwatch.scala
@@ -45,8 +45,15 @@ object Stopwatch {
 
       /* Estimate the uncertainty in the mean */
       errorEstimate = if (times.size > 1) {
+        // We have a small number of samples, so the distribution will be a student's T distribution
         val dist = new TDistribution(times.size - 1)
-        dist.inverseCumulativeProbability(1.0 - (1.0 - confidence)/2.0) * Math.sqrt(variance / times.size) / mean
+        // Where on the t-distribution do we achieve the desired level of confidence?
+        val x = dist.inverseCumulativeProbability(1.0 - (1.0 - confidence)/2.0)
+        // Convert from the position in the t-distribution to the uncertainty in the mean,
+        // relative to the estimate of the mean
+        // Note that we're dividing the uncertainty in the mean by the estimated, not true, mean
+        // That adds a second order correction that we're ignoring here
+        x * Math.sqrt(variance / times.size) / mean
       } else {
         Double.MaxValue
       }

--- a/src/test/scala/io/citrine/theta/BenchmarkRegistryTest.scala
+++ b/src/test/scala/io/citrine/theta/BenchmarkRegistryTest.scala
@@ -25,7 +25,7 @@ class BenchmarkRegistryTest {
   @Category(Array(classOf[SlowTest]))
   def testConsistencyRandomGeneration(): Unit = {
     (0 until 32).foreach{ i =>
-      val theta: Double = Stopwatch.time(RandomGenerationBenchmark.kernel(), benchmark = "RandomGeneration")
+      val theta: Double = Stopwatch.time(RandomGenerationBenchmark.kernel(), benchmark = "RandomGeneration", targetError = 0.01)
       assert(theta < 1.1, s"RandomGeneration benchmark inconsistent (too slow ${theta})")
       assert(theta > 0.9, s"RandomGeneration benchmark inconsistent (too fast ${theta})")
     }
@@ -37,9 +37,9 @@ class BenchmarkRegistryTest {
     val benchmark = new StreamBenchmark()
     benchmark.setup()
     (0 until 8).foreach{ i =>
-      val theta: Double = Stopwatch.time(benchmark.kernel(), benchmark = "STREAM")
-      assert(theta < 1.1, s"STREAM benchmark inconsistent (too slow ${theta})")
-      assert(theta > 0.9, s"STREAM benchmark inconsistent (too fast ${theta})")
+      val theta: Double = Stopwatch.time(benchmark.kernel(), benchmark = "STREAM", targetError = 0.01)
+      assert(theta < 1.1, s"STREAM benchmark inconsistent (too slow on it ${i} (${theta}))")
+      assert(theta > 0.9, s"STREAM benchmark inconsistent (too fast on it ${i} (${theta}))")
     }
     benchmark.teardown()
   }


### PR DESCRIPTION
This contextualizes the error estimate, since the mean follows a t-distribution.  Defaults are set to 5% error with 95% confidence.