### PR TITLE
Bugfix: race condition benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>theta</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A portable timing library</description>

--- a/src/main/scala/io/citrine/theta/BenchmarkRegistry.scala
+++ b/src/main/scala/io/citrine/theta/BenchmarkRegistry.scala
@@ -1,6 +1,6 @@
 package io.citrine.theta
 
-import io.citrine.theta.benchmarks.{Benchmark, RandomGenerationBenchmark, StreamBenchmark}
+import io.citrine.theta.benchmarks.{BenchmarkBuilder, RandomGenerationBenchmark, StreamBenchmark}
 
 import scala.collection.mutable
 
@@ -25,7 +25,8 @@ object BenchmarkRegistry {
       case None =>
         benchmarks.get(name) match {
           case None => throw new IllegalArgumentException("Unknown benchmark name")
-          case Some(bm) =>
+          case Some(bmb) =>
+            val bm = bmb.build()
             bm.run()
             val time = bm.run()
             times(name) = time
@@ -45,7 +46,7 @@ object BenchmarkRegistry {
 
     benchmarks.get(name) match {
       case None => throw new IllegalArgumentException()
-      case Some(bm) => bm.getCount()
+      case Some(bmb) => bmb.build().getCount()
     }
   }
 
@@ -54,7 +55,7 @@ object BenchmarkRegistry {
     * @param name of the benchmark
     * @param bm object to register
     */
-  def register(name: String, bm: Benchmark): Unit = {
+  def register(name: String, bm: BenchmarkBuilder): Unit = {
     benchmarks(name) = bm
   }
 
@@ -66,9 +67,9 @@ object BenchmarkRegistry {
   }
 
   /** Map from name to benchmark object */
-  val benchmarks: mutable.Map[String, Benchmark] = mutable.HashMap()
+  val benchmarks: mutable.Map[String, BenchmarkBuilder] = mutable.HashMap()
   register("RandomGeneration", RandomGenerationBenchmark)
-  register("STREAM", new StreamBenchmark())
+  register("STREAM", StreamBenchmark)
 
   /** Map from name to benchmark time */
   val times: mutable.Map[String, Double] = mutable.HashMap()

--- a/src/main/scala/io/citrine/theta/BenchmarkRegistry.scala
+++ b/src/main/scala/io/citrine/theta/BenchmarkRegistry.scala
@@ -26,11 +26,12 @@ object BenchmarkRegistry {
         benchmarks.get(name) match {
           case None => throw new IllegalArgumentException("Unknown benchmark name")
           case Some(bmb) =>
-            val bm = bmb.build()
-            bm.run()
-            val time = bm.run()
-            times(name) = time
-            time
+            synchronized {
+              val bm = bmb.build()
+              val time = bm.run()
+              times(name) = time
+              time
+            }
         }
     }
   }

--- a/src/main/scala/io/citrine/theta/benchmarks/Benchmark.scala
+++ b/src/main/scala/io/citrine/theta/benchmarks/Benchmark.scala
@@ -41,3 +41,7 @@ trait Benchmark {
     */
   def teardown(): Unit = {}
 }
+
+trait BenchmarkBuilder {
+  def build(): Benchmark
+}

--- a/src/main/scala/io/citrine/theta/benchmarks/RandomGenerationBenchmark.scala
+++ b/src/main/scala/io/citrine/theta/benchmarks/RandomGenerationBenchmark.scala
@@ -6,7 +6,7 @@ import scala.util.Random
   * Benchmark that generates random numbers
   * Created by maxhutch on 3/29/17.
   */
-object RandomGenerationBenchmark extends Benchmark {
+class RandomGenerationBenchmark() extends Benchmark {
 
   val N: Long = 8 * 1048576L
 
@@ -20,4 +20,8 @@ object RandomGenerationBenchmark extends Benchmark {
   }
 
   override def getCount(): Long = N
+}
+
+object RandomGenerationBenchmark extends BenchmarkBuilder {
+  override def build(): Benchmark = new RandomGenerationBenchmark()
 }

--- a/src/main/scala/io/citrine/theta/benchmarks/StreamBenchmark.scala
+++ b/src/main/scala/io/citrine/theta/benchmarks/StreamBenchmark.scala
@@ -44,3 +44,7 @@ class StreamBenchmark() extends Benchmark {
 
   override def getCount(): Long = 10L * N
 }
+
+object StreamBenchmark extends BenchmarkBuilder {
+  override def build(): Benchmark = new StreamBenchmark()
+}

--- a/src/test/scala/io/citrine/theta/BenchmarkRegistryTest.scala
+++ b/src/test/scala/io/citrine/theta/BenchmarkRegistryTest.scala
@@ -25,7 +25,7 @@ class BenchmarkRegistryTest {
   @Category(Array(classOf[SlowTest]))
   def testConsistencyRandomGeneration(): Unit = {
     (0 until 32).foreach{ i =>
-      val theta: Double = Stopwatch.time(RandomGenerationBenchmark.kernel(), benchmark = "RandomGeneration", targetError = 0.01)
+      val theta: Double = Stopwatch.time(new RandomGenerationBenchmark().kernel(), benchmark = "RandomGeneration", targetError = 0.01)
       assert(theta < 1.1, s"RandomGeneration benchmark inconsistent (too slow ${theta})")
       assert(theta > 0.9, s"RandomGeneration benchmark inconsistent (too fast ${theta})")
     }

--- a/src/test/scala/io/citrine/theta/ProfilerTest.scala
+++ b/src/test/scala/io/citrine/theta/ProfilerTest.scala
@@ -16,9 +16,10 @@ class ProfilerTest {
     */
   @Test
   def testTimeDefault(): Unit = {
+    val bm = new RandomGenerationBenchmark()
     val report = new Profiler("test", benchmark = "RandomGeneration").profile{c: Counter =>
-      RandomGenerationBenchmark.kernel()
-      c.count(RandomGenerationBenchmark.getCount())
+      bm.kernel()
+      c.count(bm.getCount())
     }
 
     assert(report.getTheta() < 1.2, s"RandomGeneration benchmark inconsistent (too slow ${report.getTheta()})")

--- a/src/test/scala/io/citrine/theta/StopwatchTest.scala
+++ b/src/test/scala/io/citrine/theta/StopwatchTest.scala
@@ -16,7 +16,7 @@ class StopwatchTest {
     */
   @Test
   def testTimeDefault(): Unit = {
-    val theta: Double = Stopwatch.time(RandomGenerationBenchmark.kernel(), benchmark = "RandomGeneration")
+    val theta: Double = Stopwatch.time(new RandomGenerationBenchmark().kernel(), benchmark = "RandomGeneration")
     assert(theta < 1.2, s"RandomGeneration benchmark inconsistent (too slow ${theta})")
     assert(theta > 0.8, s"RandomGeneration benchmark inconsistent (too fast ${theta})")
   }


### PR DESCRIPTION
Two fixes:
 - The reference benchmarks could be shared across threads, resulting in critical failures if one called `cleanup` while the other was running
 - Benchmarks weren't protected from from being run thread-parallel, which could lead to very long benchmark runtimes (for convergence) or misleading reference values