### PR TITLE
Update to scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
                 <version>2.19.1</version>
                 <configuration>
                     <excludedGroups>io.citrine.theta.SlowTest</excludedGroups>
+                    <argLine>-Xmx4096m</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>theta</artifactId>
-    <version>0.2.1</version>
+    <version>1.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A portable timing library</description>
@@ -36,6 +36,12 @@
 
 
     <properties>
+        <breeze.version>0.13.2</breeze.version>
+        <math3.version>3.6.1</math3.version>
+        <netlib.version>1.1.2</netlib.version>
+        <junit.version>4.12</junit.version>
+        <scala-maven-plugin.version>3.2.1</scala-maven-plugin.version>
+        <scala.version>2.12.4</scala.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -44,30 +50,30 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.fommil.netlib</groupId>
             <artifactId>all</artifactId>
-            <version>1.1.2</version>
+            <version>${netlib.version}</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.scalanlp</groupId>
-            <artifactId>breeze_2.11</artifactId> <!-- or 2.11 -->
-            <version>0.12</version>
+            <artifactId>breeze_2.12</artifactId> <!-- or 2.11 -->
+            <version>${breeze.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-math3 -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
-            <version>3.6.1</version>
+            <version>${math3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.11.7</version>
+            <version>${scala.version}</version>
         </dependency>
     </dependencies>
 
@@ -130,9 +136,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
-                <version>2.14.2</version>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>${scala-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>scala-compile-first</id>
@@ -143,9 +149,16 @@
                         </goals>
                     </execution>
                     <execution>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
                         <goals>
-                            <goal>compile</goal>
                             <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>doc-jar</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -232,33 +245,6 @@
                                 <id>attach-javadocs</id>
                                 <goals>
                                     <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <!-- see http://davidb.github.com/scala-maven-plugin -->
-                        <groupId>net.alchim31.maven</groupId>
-                        <artifactId>scala-maven-plugin</artifactId>
-                        <version>3.2.1</version>
-                        <executions>
-                            <execution>
-                                <id>Compile</id>
-                                <goals>
-                                    <goal>compile</goal>
-                                    <goal>testCompile</goal>
-                                </goals>
-                                <configuration>
-                                    <args>
-                                        <arg>-dependencyfile</arg>
-                                        <arg>${project.build.directory}/.scala_dependencies</arg>
-                                    </args>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>doc-jar</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,6 @@
                 <version>2.19.1</version>
                 <configuration>
                     <excludedGroups>io.citrine.theta.SlowTest</excludedGroups>
-                    <argLine>-Xmx4096m</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/scala/io/citrine/theta/benchmarks/StreamBenchmark.scala
+++ b/src/main/scala/io/citrine/theta/benchmarks/StreamBenchmark.scala
@@ -7,7 +7,7 @@ import scala.util.Random
   * Created by maxhutch on 3/29/17.
   */
 class StreamBenchmark() extends Benchmark {
-  val N: Int = 33554432
+  val N: Int = 16777216
 
   var a: Array[Double] = Array()
   var b: Array[Double] = Array()


### PR DESCRIPTION
Scala 2.12 is not binary compatible with 2.11, so this is a
breaking (major version) change.