### PR TITLE
Upgrade breeze to v1.2. Only include netlib pom.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,12 +1,13 @@
 import sbt._
 
 object Dependencies {
+  lazy val netlibVersion = "1.1.2"
   lazy val junitVersion = "4.13.1"
   lazy val breezeVersion = "1.2"
 
   val thetaDeps = Seq(
+    "com.github.fommil.netlib" % "all" % netlibVersion pomOnly(),
     "org.scalanlp" %% "breeze" % breezeVersion,
-    "org.scalanlp" %% "breeze-natives" % breezeVersion,
     "junit" % "junit" % junitVersion % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test"
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,13 +1,12 @@
 import sbt._
 
 object Dependencies {
-  lazy val netlibVersion = "1.1.2"
   lazy val junitVersion = "4.13.1"
-  lazy val breezeVersion = "1.1"
+  lazy val breezeVersion = "1.2"
 
   val thetaDeps = Seq(
-    "com.github.fommil.netlib" % "all" % netlibVersion,
     "org.scalanlp" %% "breeze" % breezeVersion,
+    "org.scalanlp" %% "breeze-natives" % breezeVersion,
     "junit" % "junit" % junitVersion % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test"
   )


### PR DESCRIPTION
This bumps the version of breeze from 1.1 to 1.2. I also included netlib as a pom only dependency.